### PR TITLE
AEP 01 - Similarity Search Module

### DIFF
--- a/aep/01_similarity_search.md
+++ b/aep/01_similarity_search.md
@@ -11,7 +11,22 @@ This AEP introduces a new module and base cass for time series similarity search
 At its simplest, similarity search is the task of finding the closest subseries in 
 series X to given series q (<= length of X) given a similarity measure.
 
-TODO: use cases and examples
+To obtain the most similar subserie, a distance vector, often called distance
+profile, must be computed. This distance profile will store the similarity
+between the query and all candidate subseries. In this context, the most 
+similar subseries will be the one with maximize the similarity measure ( or
+minimize the distance or dissimilarity).
+
+The main research challenge for the distance profiles is the computational 
+complexity. Most of the contributions in the litterature are aimed toward
+optimizing the (di)similarity functions (e.g. Mueen algortihm for the 
+normalized euclidean distance), proposing lower bounds to prune subseries,
+or approximations methods. 
+
+In terms of use cases, distance profiles are the base component of the matrix 
+profile.
+
+TODO: add more use cases and references
 
 ## Implementation
 

--- a/aep/01_similarity_search.md
+++ b/aep/01_similarity_search.md
@@ -1,0 +1,56 @@
+# Time Series Similarity Search Module
+
+## Overview
+
+This AEP introduces a new module and base cass for time series similarity search.
+
+## Problem Statement and Use Cases
+
+At its simplest, similarity search is the task of finding the closest subseries in 
+series X to given series q (<= length of X) given a similarity measure.
+
+TODO: use cases and examples
+
+## Implementation
+
+- new package
+- new base class
+- example subclass
+
+## Examples code/structure (if applicable)
+
+Base class: 
+
+- BaseSimilaritySearch
+    - methods:
+      - \_\_init\_\_(distance, normalise?): 
+          - takes distance: function, default = euclidean. 
+      - fit(X): 
+          - takes X: a single/multiple univariate/multivariate series (internal type?) tbc
+          - returns self
+      - predict(q): 
+          - takes q: a single/multiple univariate/multivariate series (internal type?) tbc
+          - iterate over X, find closest k matches, some abstract method to do the iteration
+          - returns indexes of closest k /distances/series?
+ 
+    - abstract:
+      - \_fit()
+      - \_predict()
+      - \_iterator()
+
+Subclasses:
+    Optimisations:
+        early abandon?
+        Distance pruning
+
+## Considerations and Alternatives
+
+TODO
+
+## Discussion
+
+TODO
+
+## References
+
+TODO

--- a/aep/01_similarity_search.md
+++ b/aep/01_similarity_search.md
@@ -1,5 +1,7 @@
 # Time Series Similarity Search Module
 
+Contributors: @MatthewMiddlehurst @TonyBagnall @baraline @hadifawaz1999
+
 ## Overview
 
 This AEP introduces a new module and base cass for time series similarity search.

--- a/aep/01_similarity_search.md
+++ b/aep/01_similarity_search.md
@@ -24,15 +24,29 @@ normalized euclidean distance), proposing lower bounds to prune subseries,
 or approximations methods. 
 
 In terms of use cases, distance profiles are the base component of the matrix 
-profile.
+profile methods[1]. They are also used in shapelets methods, where the
+shapelet is viewed as the query), convolutional kernels (e.g. Rocket) or 
+more generaly, any method using a sliding window to compute a function between
+a fixed query (a kernel, a shapelet, ...) and a (collection of) time series.
 
-TODO: add more use cases and references
+Altough, the computational optimizations used in the similarity search 
+litterature have not been widely adopted or explored in other the less
+"obvious" contexts such as shapelets.
 
 ## Implementation
 
-- new package
-- new base class
-- example subclass
+The current implementation is designed around a new module named
+`similarity_search`, which contains `BaseSimilaritySearch`, a 
+base class for all applications that use a distance profile to
+extract a set of subseries. One subclass is `TopKSimilaritySearch`,
+which given a collection of time series and a query, will return 
+the most `k` similar subseries given a distance function.
+
+A submodule named `distance_profiles` contains the methods used
+to compute distance profiles for different distance functions.
+One additional goal of this submodule would be to provide optimized
+methods to compute distance profiles for other tasks that do not fit
+the similarity search module (e.g. shapelets).
 
 ## Examples code/structure (if applicable)
 
@@ -40,34 +54,49 @@ Base class:
 
 - BaseSimilaritySearch
     - methods:
-      - \_\_init\_\_(distance, normalise?): 
-          - takes distance: function, default = euclidean. 
+      - \_\_init\_\_(distance, normalise, store_distance_profile): 
+          - takes distance: function, default = euclidean.
+          - wheter to use a z-normalized distance
+          - if the distance profiles should be stored after calling predict
       - fit(X): 
-          - takes X: a single/multiple univariate/multivariate series (internal type?) tbc
+          - takes X: a 3D array : collection of multivariate series. How other
+            modules handle the case where we have a 2D array as input ? (i.e.
+            is it a collection of univariate series or a multivariate series)
+          - fetch the distance profile function linked to the distance and normalize parameters.
           - returns self
-      - predict(q): 
-          - takes q: a single/multiple univariate/multivariate series (internal type?) tbc
-          - iterate over X, find closest k matches, *some abstract method to do the iteration)
-          - returns indexes of closest k /distances/series?
- 
+      - predict(q, q_index=None, exclusion_factor=2.0): 
+          - takes q: a single multivariate series (internal type?) tbc
+          - q_index to as a tuple (id_sample, id_timestamp) to specify if q was extracted from X
+          - Initiate the boolean mask of same shape as X given to the child classes and the
+            distance profile function, which store the part of the distance profile that should
+            not be computed. This can be used to indicate where the query was sampled in X, but
+            also during lower bound pruning to indicate which part are prunned.  
+          - exlucsion_factor specify the area around q_index (+/- l//exclusion_factor) that should
+            be excluded from the distance profile computation and left to np.inf.
+          - Compute the means and standard deviations of the subseries in X if normalize was True.
+           
     - abstract:
-      - \_fit()
+      - \_fit() :
       - \_predict()
       - \_iterator() maybe?
 
-Subclasses:
-    Optimisations:
-        early abandon?
-        Distance pruning
-
+For the `distance_profile` submodule, we can distinguish different type of optimizations:
+    - Direct distance function optimization (e.g. Mueen)
+    - Early abandon of distance computation (e.g. EA-DTW)
+    - Lower bound pruning (e.g. Keogh LB for DTW)
+    
 ## Considerations and Alternatives
 
-do we even need a base class? Maybe just have a suite of functions?
+- do we even need a base class? Maybe just have a suite of functions?
 
 ## Discussion
 
-TODO
+I think base class can be useful to define the common code between some similarity search
+use cases. For example, TopK search or threshold search (i.e. all subseries with a distance
+bellow a threshold are returned). We might need to refine it when we extend the scope of
+the module (e.g. matrix profile), as I don't think the current `BaseSimilaritySearch` class
+would fit all applications.
 
 ## References
 
-TODO
+[1] https://www.cs.ucr.edu/~eamonn/MatrixProfile.html

--- a/aep/01_similarity_search.md
+++ b/aep/01_similarity_search.md
@@ -32,13 +32,13 @@ Base class:
           - returns self
       - predict(q): 
           - takes q: a single/multiple univariate/multivariate series (internal type?) tbc
-          - iterate over X, find closest k matches, some abstract method to do the iteration
+          - iterate over X, find closest k matches, *some abstract method to do the iteration)
           - returns indexes of closest k /distances/series?
  
     - abstract:
       - \_fit()
       - \_predict()
-      - \_iterator()
+      - \_iterator() maybe?
 
 Subclasses:
     Optimisations:
@@ -47,7 +47,7 @@ Subclasses:
 
 ## Considerations and Alternatives
 
-TODO
+do we even need a base class? Maybe just have a suite of functions?
 
 ## Discussion
 


### PR DESCRIPTION
introduces a similarity search module. See

https://github.com/aeon-toolkit/aeon/pull/724

and the AEP document. Similarity search is a primitive of many operations, so the design is a bit unclear. We would like to get this first version in then consider the use cases. It may be we dont need a base class and can represent it as a bunch of functions like distances would be good to consider the use cases here (list more below)

1. As a task in its own right: the basic query operation seems valid. The general research issue as I understand it is how to approximate Euclidean distance for subseries matching much faster than niavely iterating. Includes lower bounding 
2. Matrix profile is essentially a nearest neighbour search
3. Shapelet and covolutions both need subseries matching 




